### PR TITLE
Update domain filter as container argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ spec:
       - name: external-dns-webhook-provider
         image: ghcr.io/konnektr-io/external-dns-porkbun-webhook:main
         imagePullPolicy: IfNotPresent
+        args:
+        - --domain-filter=YOUR_DOMAIN
         env:
         - name: GO_LOG
           value: "debug"
-        - name: DOMAIN_FILTER
-          value: YOUR_DOMAIN
         - name: API_KEY
           valueFrom:
             secretKeyRef:

--- a/example/external-dns.yaml
+++ b/example/external-dns.yaml
@@ -77,8 +77,6 @@ spec:
         env:
         - name: GO_LOG
           value: "debug"
-        - name: DOMAIN_FILTER
-          value: YOUR_DOMAIN
         - name: API_KEY
           valueFrom:
             secretKeyRef:

--- a/example/external-dns.yaml
+++ b/example/external-dns.yaml
@@ -65,6 +65,8 @@ spec:
       - name: external-dns-webhook-provider
         image: ghcr.io/konnektr-io/external-dns-porkbun-webhook:main
         imagePullPolicy: IfNotPresent
+        args:
+        - --domain-filter=YOUR_DOMAIN
         resources:
           requests:
             memory: "64Mi"


### PR DESCRIPTION
Instead of using the env variable, it is better to use the argument. The reason is because if you manage two or more domains, you have to specify them in the following way:

```yaml
args:
  - --domain-filter=domain1.com
  - --domain-filter=domain2.com
```


Because setting two env variables does not work. Changing that with args worked for me.